### PR TITLE
Bug fix with using application default credentials

### DIFF
--- a/client/proxy.go
+++ b/client/proxy.go
@@ -132,7 +132,7 @@ func (p *Proxy) getCredentials(ctx context.Context) error {
 	var err error
 
 	if p.UseDefaultCredentials || !gcloudconfig.IsGCloudOnPath() {
-		p.credentials, err = google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform.read-only")
+		p.credentials, err = google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
 	} else {
 		p.credentials, err = gcloudconfig.GetCredentials(p.ConfigurationName)
 	}


### PR DESCRIPTION
Love this project! I was not able to use application default credentials, it would return with this error: 

```
2023/09/29 12:41:52 ERROR: failed to obtain token for my-service-account@my-project.iam.gserviceaccount.com, impersonate: status code 403: {
  "error": {
    "code": 403,
    "message": "Request had insufficient authentication scopes.",
    "status": "PERMISSION_DENIED",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
        "reason": "ACCESS_TOKEN_SCOPE_INSUFFICIENT",
        "domain": "googleapis.com",
        "metadata": {
          "service": "iamcredentials.googleapis.com",
          "method": "google.iam.credentials.v1.IAMCredentials.GenerateIdToken"
        }
      }
    ]
  }
}
```

The fix was to remove `.read-only` from the `cloud-platform` scope. 
